### PR TITLE
eliminate duplicate build commands

### DIFF
--- a/admob/build.gradle.kts
+++ b/admob/build.gradle.kts
@@ -119,10 +119,7 @@ tasks.named<Delete>("clean").apply {
 }
 
 afterEvaluate {
-    tasks.named("assembleDebug").configure {
-        finalizedBy(copyAddonsToDemo)
-    }
-    tasks.named("assembleRelease").configure {
+    tasks.named("assemble").configure {
         finalizedBy(copyAddonsToDemo)
     }
 }


### PR DESCRIPTION
It appears that both assembleDebug and assembleRelease are finalized by the same function, and that function appears to compile both releases either way.

This brings your repo close to the original [Godot-Android-Plugin-Template](https://github.com/m4gr3d/Godot-Android-Plugin-Template)

If I am missing something, and you want to have multiple calls to run gradle, please feel free to close this PR.

I am also curious if you can share why these commands are wrapped in this `afterEvaluate` block? I see [the docs](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-project/after-evaluate.html) here, but I am not really sure what doing this accomplishes for the project, or why it is neccesary.

Thanks!